### PR TITLE
Update Customer API title to FCA

### DIFF
--- a/sales/customer/openapi.yaml
+++ b/sales/customer/openapi.yaml
@@ -7,7 +7,7 @@ info:
     KongAir Customer Information service provides customer information
     (payment methods, contact info, frequent flyer, etc...)
   version: 0.1.0
-  title: Customer Information Service
+  title: Customer Information Service FCA
 
 servers:
 - url: http://localhost:8083


### PR DESCRIPTION
## Summary
- Updates `info.title` in `sales/customer/openapi.yaml` from `Customer Information Service` to `Customer Information Service FCA`
- Triggers Dev Portal and Konnect Catalog spec republishing

## Test plan
- [ ] Verify `deploy-kong-PRD` workflow triggers on merge
- [ ] Confirm Customer title updates to `Customer Information Service FCA` in Dev Portal
- [ ] Confirm Customer title updates in Konnect Catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)